### PR TITLE
will return an empty list if dependabot is not enabled

### DIFF
--- a/check_alerts.py
+++ b/check_alerts.py
@@ -90,9 +90,12 @@ def get_github_repo(github: Github):
 def get_dependabot_alerts(repo):
     try:
         alerts = repo.get_dependabot_alerts()
-        print("returned alerts")
+        alerts_list = list(alerts)
+        print(f"Returned {len(alerts_list)} alerts")
         return alerts
     except GithubException as e:
+        if e.status == 403 and e.data.get('message', '') == "Dependabot alerts are disabled for this repository.":
+            return []
         print(f"Error: {e}")
         if e.status == 403:
             print("Error: Insufficient permissions to access Dependabot alerts")

--- a/test_check_alerts.py
+++ b/test_check_alerts.py
@@ -236,8 +236,8 @@ class TestGetDependabotAlerts(unittest.TestCase):
         self.repo.get_dependabot_alerts.side_effect = GithubException(
             403,
             {
-                "message": "Dependabot alerts are disabled for this repository.", 
-                "documentation_url": "https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository", 
+                "message": "Dependabot alerts are disabled for this repository.",
+                "documentation_url": "https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository",
                 "status": "403"
             }
         )

--- a/test_check_alerts.py
+++ b/test_check_alerts.py
@@ -217,7 +217,7 @@ class TestGetDependabotAlerts(unittest.TestCase):
         self.repo.get_dependabot_alerts.assert_called_once()
 
     def test_get_dependabot_alerts_github_exception(self):
-        self.repo.get_dependabot_alerts.side_effect = GithubException(403, "Forbidden", None)
+        self.repo.get_dependabot_alerts.side_effect = GithubException(403, {"message": "Forbidden"})
 
         with self.assertRaises(SystemExit) as cm:
             get_dependabot_alerts(self.repo)
@@ -230,6 +230,20 @@ class TestGetDependabotAlerts(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             get_dependabot_alerts(self.repo)
         self.assertEqual(str(cm.exception), "General error")
+        self.repo.get_dependabot_alerts.assert_called_once()
+
+    def test_get_dependabot_alerts_disabled(self):
+        self.repo.get_dependabot_alerts.side_effect = GithubException(
+            403,
+            {
+                "message": "Dependabot alerts are disabled for this repository.", 
+                "documentation_url": "https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository", 
+                "status": "403"
+            }
+        )
+
+        alerts = get_dependabot_alerts(self.repo)
+        self.assertEqual(alerts, [])
         self.repo.get_dependabot_alerts.assert_called_once()
 
 class TestAnalyzeAlerts(unittest.TestCase):


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Issue #5 describes the action failing when the target repository does not have Dependabot enabled. This failure was occurring when the paginatedList was being traversed in the analyze_alerts method indicating that the exception handling for the 403 response was not being performed correctly.

This fix is to return an empty list for this scenario and to ensure that handling of a 403 lack of permissions is performed as expected.

## Context

This was causing the action to fail and block pipelines where dependabot was not enabled, for now the solution is to return an empty list - we might want to consider alternative approaches to detect disabled Dependabot.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
