### PR TITLE
skipping check if PR is from Dependabot

### DIFF
--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -125,9 +125,9 @@ jobs:
           idp_aws_report_upload_role_name: "${{ secrets.IDP_AWS_REPORT_UPLOAD_ROLE_NAME }}"
           idp_aws_report_upload_bucket_endpoint: "${{ secrets.IDP_AWS_REPORT_UPLOAD_BUCKET_ENDPOINT }}"
   dependabot-policy-enforcer:
+    if: github.actor != 'dependabot[bot]'
     name: "Dependabot policy enforcer"
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ permissions:
 
 jobs:
   check-alerts:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: nhs-england-tools/dependabot-policy-enforcer


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updating README to reflect the neccessary changes to GitHub actions to ensure that PRs created by Dependabot skip these checks.

## Context

Dependabot doesn't have access tot he secrets that enable this workflow to complete successfully. Rather than giving access to these secrets and to ensure that Dependabot runs - which will typically resolve the issues the enforcer is warning about - will not be blocked.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [X] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
